### PR TITLE
[SUPERSEDED by #73] Default theme_docx_default() font size to 8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Exported functions `apply_alignments()`, `apply_bold_manual()` and `extract_font_and_size_from_flx()` (#66)
 * Minor fix in `apply_alignments()` to update alignments in specific cells of the flextable.
+* `theme_docx_default()` now defaults to `font_size = 8` (was 9) to match the standard TLG body font size. Pass `font_size = 9` to restore the previous output. (#71)
 
 ## rtables.officer 0.1.2
 

--- a/R/theme_defaults.R
+++ b/R/theme_defaults.R
@@ -5,7 +5,8 @@
 #'
 #' @param font (`string`)\cr font. Defaults to `"Arial"`. If the font given is not available, the `flextable` default
 #'   is used instead. For options, consult the family column from `systemfonts::system_fonts()`.
-#' @param font_size (`integer(1)`)\cr font size. Defaults to 9.
+#' @param font_size (`integer(1)`)\cr font size. Defaults to 8 for `theme_docx_default()` and 9 for
+#'   `theme_html_default()`.
 #' @param cell_margins (`numeric(1)` or `numeric(4)`)\cr a numeric or a vector of four numbers indicating
 #'   `c("left", "right", "top", "bottom")`. It defaults to 0 for top and bottom, and to 0.19 `mm` in Word `pt`
 #'   for left and right.
@@ -56,7 +57,7 @@
 #'
 #' @export
 theme_docx_default <- function(font = "Arial",
-                               font_size = 9,
+                               font_size = 8,
                                cell_margins = c(word_mm_to_pt(1.9), word_mm_to_pt(1.9), 0, 0), # Default in docx
                                bold = c("header", "content_rows", "label_rows", "top_left"),
                                bold_manual = NULL,

--- a/man/tt_to_flextable.Rd
+++ b/man/tt_to_flextable.Rd
@@ -123,7 +123,8 @@ See \code{flextable::set_table_properties(layout)} for more details.}
 \item{font}{(\code{string})\cr font. Defaults to \code{"Arial"}. If the font given is not available, the \code{flextable} default
 is used instead. For options, consult the family column from \code{systemfonts::system_fonts()}.}
 
-\item{font_size}{(\code{integer(1)})\cr font size. Defaults to 9.}
+\item{font_size}{(\code{integer(1)})\cr font size. Defaults to 8 for \code{theme_docx_default()} and 9 for
+\code{theme_html_default()}.}
 
 \item{cell_margins}{(\code{numeric(1)} or \code{numeric(4)})\cr a numeric or a vector of four numbers indicating
 \code{c("left", "right", "top", "bottom")}. It defaults to 0 for top and bottom, and to 0.19 \code{mm} in Word \code{pt}

--- a/tests/testthat/test-extract_from_flx.R
+++ b/tests/testthat/test-extract_from_flx.R
@@ -30,13 +30,13 @@ test_that("extract_font_and_size_from_flx works as expected", {
   expect_no_error(res <- extract_font_and_size_from_flx(out))
   expect_equal(names(res), c("fpt", "fpt_footer"))
   expect_equal(res[["fpt"]],
-               flextable::fp_text_default(font.size = 9,
+               flextable::fp_text_default(font.size = 8,
                                           font.family = "Arial",
                                           hansi.family = "Arial",
                                           eastasia.family = "Arial",
                                           cs.family = "Arial"))
   expect_equal(res[["fpt_footer"]],
-               flextable::fp_text_default(font.size = 8,
+               flextable::fp_text_default(font.size = 7,
                                           font.family = "Arial",
                                           hansi.family = "Arial",
                                           eastasia.family = "Arial",


### PR DESCRIPTION
Superseded by #73 (corrected authorship and review fixes). This PR is closed and its branch deleted; no action needed here.