### PR TITLE
Default theme_docx_default() font size to 8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,6 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Collate:
     'add_flextable_separators.R'
     'as_flextable.R'
@@ -72,3 +71,4 @@ Collate:
     'theme_defaults.R'
     'apply_styling.R'
     'extract_from_flx.R'
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Exported functions `apply_alignments()`, `apply_bold_manual()` and `extract_font_and_size_from_flx()` (#66)
 * Minor fix in `apply_alignments()` to update alignments in specific cells of the flextable.
-* `theme_docx_default()` now defaults to `font_size = 8` (was 9) to match the standard TLG body font size. Pass `font_size = 9` to restore the previous output. (#71)
+* `theme_docx_default()` and `theme_html_default()` now default to `font_size = 8` (was 9) to match the standard TLG body font size. Pass `font_size = 9` to restore the previous output. (#71)
 
 ## rtables.officer 0.1.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Exported functions `apply_alignments()`, `apply_bold_manual()` and `extract_font_and_size_from_flx()` (#66)
 * Minor fix in `apply_alignments()` to update alignments in specific cells of the flextable.
+* `theme_docx_default()` now defaults to `font_size = 8` (was 9) to match the standard TLG body font size. Pass `font_size = 9` to restore the previous output. (#71)
 
 ## rtables.officer 0.1.2
 

--- a/R/theme_defaults.R
+++ b/R/theme_defaults.R
@@ -5,7 +5,8 @@
 #'
 #' @param font (`string`)\cr font. Defaults to `"Arial"`. If the font given is not available, the `flextable` default
 #'   is used instead. For options, consult the family column from `systemfonts::system_fonts()`.
-#' @param font_size (`integer(1)`)\cr font size. Defaults to 9.
+#' @param font_size (`integer(1)`)\cr font size. Defaults to 8 for `theme_docx_default()` and 9 for
+#'   `theme_html_default()`.
 #' @param cell_margins (`numeric(1)` or `numeric(4)`)\cr a numeric or a vector of four numbers indicating
 #'   `c("left", "right", "top", "bottom")`. It defaults to 0 for top and bottom, and to 0.19 `mm` in Word `pt`
 #'   for left and right.
@@ -56,7 +57,7 @@
 #'
 #' @export
 theme_docx_default <- function(font = "Arial",
-                               font_size = 9,
+                               font_size = 8,
                                cell_margins = c(word_mm_to_pt(1.9), word_mm_to_pt(1.9), 0, 0), # Default in docx
                                bold = c("header", "content_rows", "label_rows", "top_left"),
                                bold_manual = NULL,

--- a/R/theme_defaults.R
+++ b/R/theme_defaults.R
@@ -5,8 +5,7 @@
 #'
 #' @param font (`string`)\cr font. Defaults to `"Arial"`. If the font given is not available, the `flextable` default
 #'   is used instead. For options, consult the family column from `systemfonts::system_fonts()`.
-#' @param font_size (`integer(1)`)\cr font size. Defaults to 8 for `theme_docx_default()` and 9 for
-#'   `theme_html_default()`.
+#' @param font_size (`integer(1)`)\cr font size. Defaults to 8.
 #' @param cell_margins (`numeric(1)` or `numeric(4)`)\cr a numeric or a vector of four numbers indicating
 #'   `c("left", "right", "top", "bottom")`. It defaults to 0 for top and bottom, and to 0.19 `mm` in Word `pt`
 #'   for left and right.
@@ -185,7 +184,7 @@ theme_docx_default <- function(font = "Arial",
 #'
 #' @export
 theme_html_default <- function(font = "Courier",
-                               font_size = 9,
+                               font_size = 8,
                                cell_margins = 0.2,
                                remove_internal_borders = "label_rows",
                                border = flextable::fp_border_default(width = 1, color = "black")) {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2,6 +2,7 @@ Customizations
 Hoffmann
 ORCID
 Rua
+TLG
 bolding
 de
 docx

--- a/man/export_as_docx.Rd
+++ b/man/export_as_docx.Rd
@@ -41,13 +41,13 @@ uses templates to achieve it. Defaults to \code{TRUE}. Consider adding your own 
 more customization.}
 
 \item{titles_as_header}{(\code{flag})\cr Controls how titles are rendered relative to the table.
-If \code{TRUE} (default), the main title (\code{\link[formatters:title_footer]{formatters::main_title()}}) and subtitles
-(\code{\link[formatters:title_footer]{formatters::subtitles()}}) are added as distinct header rows within the
+If \code{TRUE} (default), the main title (\code{\link[formatters:main_title]{formatters::main_title()}}) and subtitles
+(\code{\link[formatters:subtitles]{formatters::subtitles()}}) are added as distinct header rows within the
 \code{flextable} object itself. If \code{FALSE}, titles are rendered as a separate paragraph
 of text placed immediately before the table.}
 
 \item{integrate_footers}{(\code{flag})\cr Controls how footers are rendered relative to the table.
-If \code{TRUE} (default), footers (e.g., \code{\link[formatters:title_footer]{formatters::main_footer()}}, \code{\link[formatters:title_footer]{formatters::prov_footer()}})
+If \code{TRUE} (default), footers (e.g., \code{\link[formatters:main_footer]{formatters::main_footer()}}, \code{\link[formatters:prov_footer]{formatters::prov_footer()}})
 are integrated directly into the \code{flextable} object, typically appearing as footnotes
 below the table body with a smaller font. If \code{FALSE}, footers are rendered as a
 separate paragraph of text placed immediately after the table.}

--- a/man/rtables.officer-package.Rd
+++ b/man/rtables.officer-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Joe Zhu \email{joe.zhu@roche.com} (\href{https://orcid.org/0000-0001-7566-2787}{ORCID})
   \item Davide Garolini \email{davide.garolini@roche.com} (\href{https://orcid.org/0000-0002-1445-1369}{ORCID})
   \item Emily de la Rua \email{emilydelarua@gmail.com} (\href{https://orcid.org/0009-0000-8738-5561}{ORCID})
   \item Abinaya Yogasekaram \email{ayogasek@gmail.com} (\href{https://orcid.org/0009-0005-2083-1105}{ORCID})

--- a/man/tt_to_flextable.Rd
+++ b/man/tt_to_flextable.Rd
@@ -123,7 +123,8 @@ See \code{flextable::set_table_properties(layout)} for more details.}
 \item{font}{(\code{string})\cr font. Defaults to \code{"Arial"}. If the font given is not available, the \code{flextable} default
 is used instead. For options, consult the family column from \code{systemfonts::system_fonts()}.}
 
-\item{font_size}{(\code{integer(1)})\cr font size. Defaults to 9.}
+\item{font_size}{(\code{integer(1)})\cr font size. Defaults to 8 for \code{theme_docx_default()} and 9 for
+\code{theme_html_default()}.}
 
 \item{cell_margins}{(\code{numeric(1)} or \code{numeric(4)})\cr a numeric or a vector of four numbers indicating
 \code{c("left", "right", "top", "bottom")}. It defaults to 0 for top and bottom, and to 0.19 \code{mm} in Word \code{pt}

--- a/man/tt_to_flextable.Rd
+++ b/man/tt_to_flextable.Rd
@@ -31,7 +31,7 @@ tt_to_flextable(
 
 theme_docx_default(
   font = "Arial",
-  font_size = 9,
+  font_size = 8,
   cell_margins = c(word_mm_to_pt(1.9), word_mm_to_pt(1.9), 0, 0),
   bold = c("header", "content_rows", "label_rows", "top_left"),
   bold_manual = NULL,
@@ -40,7 +40,7 @@ theme_docx_default(
 
 theme_html_default(
   font = "Courier",
-  font_size = 9,
+  font_size = 8,
   cell_margins = 0.2,
   remove_internal_borders = "label_rows",
   border = flextable::fp_border_default(width = 1, color = "black")
@@ -63,8 +63,8 @@ similar to the \code{rtables} default will be produced. See Details below for mo
 1 mm (2.83 pt) by default.}
 
 \item{titles_as_header}{(\code{flag})\cr Controls how titles are rendered relative to the table.
-If \code{TRUE} (default), the main title (\code{\link[formatters:title_footer]{formatters::main_title()}}) and subtitles
-(\code{\link[formatters:title_footer]{formatters::subtitles()}}) are added as distinct header rows within the
+If \code{TRUE} (default), the main title (\code{\link[formatters:main_title]{formatters::main_title()}}) and subtitles
+(\code{\link[formatters:subtitles]{formatters::subtitles()}}) are added as distinct header rows within the
 \code{flextable} object itself. If \code{FALSE}, titles are rendered as a separate paragraph
 of text placed immediately before the table.}
 
@@ -72,7 +72,7 @@ of text placed immediately before the table.}
 integers are provided, these integers are used as indices for lines at which titles should be bold.}
 
 \item{integrate_footers}{(\code{flag})\cr Controls how footers are rendered relative to the table.
-If \code{TRUE} (default), footers (e.g., \code{\link[formatters:title_footer]{formatters::main_footer()}}, \code{\link[formatters:title_footer]{formatters::prov_footer()}})
+If \code{TRUE} (default), footers (e.g., \code{\link[formatters:main_footer]{formatters::main_footer()}}, \code{\link[formatters:prov_footer]{formatters::prov_footer()}})
 are integrated directly into the \code{flextable} object, typically appearing as footnotes
 below the table body with a smaller font. If \code{FALSE}, footers are rendered as a
 separate paragraph of text placed immediately after the table.}
@@ -95,7 +95,7 @@ calculating string widths and heights, as returned by \code{\link[formatters:fon
 \code{NA} (the default) indicates \code{cpp} should be inferred from the page size; \code{NULL} indicates no horizontal
 pagination should be done regardless of page size.}
 
-\item{...}{(\code{any})\cr additional parameters to be passed to the pagination function. See \code{\link[rtables:paginate]{rtables::paginate_table()}}
+\item{...}{(\code{any})\cr additional parameters to be passed to the pagination function. See \code{\link[rtables:paginate_table]{rtables::paginate_table()}}
 for options. If \code{paginate = FALSE} this argument is ignored.}
 
 \item{colwidths}{(\code{numeric})\cr column widths for the resulting flextable(s). If \code{NULL}, the column widths estimated

--- a/man/tt_to_flextable.Rd
+++ b/man/tt_to_flextable.Rd
@@ -123,8 +123,7 @@ See \code{flextable::set_table_properties(layout)} for more details.}
 \item{font}{(\code{string})\cr font. Defaults to \code{"Arial"}. If the font given is not available, the \code{flextable} default
 is used instead. For options, consult the family column from \code{systemfonts::system_fonts()}.}
 
-\item{font_size}{(\code{integer(1)})\cr font size. Defaults to 8 for \code{theme_docx_default()} and 9 for
-\code{theme_html_default()}.}
+\item{font_size}{(\code{integer(1)})\cr font size. Defaults to 8.}
 
 \item{cell_margins}{(\code{numeric(1)} or \code{numeric(4)})\cr a numeric or a vector of four numbers indicating
 \code{c("left", "right", "top", "bottom")}. It defaults to 0 for top and bottom, and to 0.19 \code{mm} in Word \code{pt}

--- a/tests/testthat/test-extract_from_flx.R
+++ b/tests/testthat/test-extract_from_flx.R
@@ -1,5 +1,4 @@
 test_that("extract_font_and_size_from_flx works as expected", {
-
   test_data_simple <- data.frame(
     USUBJID = paste0("S", 1:3),
     ARM = c("A", "A", "B"),
@@ -29,22 +28,31 @@ test_that("extract_font_and_size_from_flx works as expected", {
   out <- tt_to_flextable(lsting)
   expect_no_error(res <- extract_font_and_size_from_flx(out))
   expect_equal(names(res), c("fpt", "fpt_footer"))
-  expect_equal(res[["fpt"]],
-               flextable::fp_text_default(font.size = 8,
-                                          font.family = "Arial",
-                                          hansi.family = "Arial",
-                                          eastasia.family = "Arial",
-                                          cs.family = "Arial"))
-  expect_equal(res[["fpt_footer"]],
-               flextable::fp_text_default(font.size = 7,
-                                          font.family = "Arial",
-                                          hansi.family = "Arial",
-                                          eastasia.family = "Arial",
-                                          cs.family = "Arial"))
+  expect_equal(
+    res[["fpt"]],
+    flextable::fp_text_default(
+      font.size = 8,
+      font.family = "Arial",
+      hansi.family = "Arial",
+      eastasia.family = "Arial",
+      cs.family = "Arial"
+    )
+  )
+  expect_equal(
+    res[["fpt_footer"]],
+    flextable::fp_text_default(
+      font.size = 7,
+      font.family = "Arial",
+      hansi.family = "Arial",
+      eastasia.family = "Arial",
+      cs.family = "Arial"
+    )
+  )
 
 
   # cases with error
-  expect_error(res <- extract_font_and_size_from_flx(NULL),
-               "Assertion on 'flx' failed: Must inherit from class 'flextable', but has class 'NULL'.")
-
+  expect_error(
+    res <- extract_font_and_size_from_flx(NULL),
+    "Assertion on 'flx' failed: Must inherit from class 'flextable', but has class 'NULL'."
+  )
 })

--- a/tests/testthat/test-extract_from_flx.R
+++ b/tests/testthat/test-extract_from_flx.R
@@ -30,13 +30,13 @@ test_that("extract_font_and_size_from_flx works as expected", {
   expect_no_error(res <- extract_font_and_size_from_flx(out))
   expect_equal(names(res), c("fpt", "fpt_footer"))
   expect_equal(res[["fpt"]],
-               flextable::fp_text_default(font.size = 9,
+               flextable::fp_text_default(font.size = 8,
                                           font.family = "Arial",
                                           hansi.family = "Arial",
                                           eastasia.family = "Arial",
                                           cs.family = "Arial"))
   expect_equal(res[["fpt_footer"]],
-               flextable::fp_text_default(font.size = 8,
+               flextable::fp_text_default(font.size = 7,
                                           font.family = "Arial",
                                           hansi.family = "Arial",
                                           eastasia.family = "Arial",


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `theme_docx_default()` and `theme_html_default()` now default to `font_size = 8` (was 9) to match the standard TLG body font size. Pass `font_size = 9` to restore the previous output. (#71)

The standard TLG body font is 8pt, but both themes defaulted to 9, rendering tables one point too large and inconsistent with consumers that use 8pt.

This is a package-wide default change, so it shifts existing output for all consumers; it is cosmetic (font size only) and easy to opt out of via the argument. Two assertions in `test-extract_from_flx.R` that pinned the old default are updated.

**Reference GitHub issue associated with pull request.**
closes #71